### PR TITLE
Shielding does not work in links

### DIFF
--- a/Markdown.php
+++ b/Markdown.php
@@ -666,11 +666,11 @@ class Markdown extends Parser
 			$offset = strlen($textMatches[0]);
 			$markdown = substr($markdown, $offset);
 
-			if (preg_match('/^\(([^\s]*?)(\s+"(.*?)")?\)/', $markdown, $refMatches)) {
+			if (preg_match('/^\(([^\s]*)(\s+"(.*?)")?\)/', $markdown, $refMatches)) {
 				// inline link
 				return [
 					$text,
-					$refMatches[1], // url
+					stripslashes($refMatches[1]), // url
 					empty($refMatches[3]) ? null: $refMatches[3], // title
 					$offset + strlen($refMatches[0]), // offset
 				];

--- a/tests/markdown-data/specs.html
+++ b/tests/markdown-data/specs.html
@@ -561,6 +561,12 @@ closely resembles the final output, as rendered in a browser. By
 allowing you to move the markup-related metadata out of the paragraph,
 you can add links without interrupting the narrative flow of your
 prose.</p>
+<p>Brackets in url and backslashes in links:</p>
+<p>About port info on wiki: <a href="http://en.wikipedia.org/wiki/Port_(computer_networking)">port</a></p>
+<p><a href="https://www.google.com">I'm an inline-style link</a></p>
+<p><a href="https://www.google.com" title="Google's Homepage">I'm an inline-style link with title</a></p>
+<p><a href="../blob/(master)/LICENSE">I'm a relative reference to a repository file</a></p>
+<p>Or leave it empty and use the <a href="">link text itself</a></p>
 <h3 id="em">Emphasis</h3>
 <p>Markdown treats asterisks (<code>*</code>) and underscores (<code>_</code>) as indicators of
 emphasis. Text wrapped with one <code>*</code> or <code>_</code> will be wrapped with an

--- a/tests/markdown-data/specs.md
+++ b/tests/markdown-data/specs.md
@@ -697,6 +697,17 @@ allowing you to move the markup-related metadata out of the paragraph,
 you can add links without interrupting the narrative flow of your
 prose.
 
+Brackets in url and backslashes in links:
+
+About port info on wiki: [port](http://en.wikipedia.org/wiki/Port_\(computer_networking\))
+
+[I'm an inline-style link](https://www.google.com)
+
+[I'm an inline-style link with title](https://www.google.com "Google's Homepage")
+
+[I'm a relative reference to a repository file](../blob/(master)/LICENSE)
+
+Or leave it empty and use the [link text itself]()
 
 <h3 id="em">Emphasis</h3>
 


### PR DESCRIPTION
Fixes #41.

Removed lazy quantifier and added preparing link url with stripslashes.
