### PR TITLE
Fix to keep single "0" alive

### DIFF
--- a/GithubMarkdown.php
+++ b/GithubMarkdown.php
@@ -64,7 +64,7 @@ class GithubMarkdown extends Markdown
 		$content = [];
 		for ($i = $current, $count = count($lines); $i < $count; $i++) {
 			$line = $lines[$i];
-			if (empty($line)
+			if (($line !== '0' && empty($line))
 				|| ltrim($line) === ''
 				|| !ctype_alpha($line[0]) && (
 					$this->identifyQuote($line, $lines, $i) ||

--- a/Markdown.php
+++ b/Markdown.php
@@ -85,7 +85,7 @@ class Markdown extends Parser
 		$content = [];
 		for ($i = $current, $count = count($lines); $i < $count; $i++) {
 			$line = $lines[$i];
-			if (!empty($line) && ltrim($line) !== '' &&
+			if (($line === '0' || !empty($line)) && ltrim($line) !== '' &&
 				!($line[0] === "\t" || $line[0] === " " && strncmp($line, '    ', 4) === 0) &&
 				!$this->identifyHeadline($line, $lines, $i))
 			{

--- a/Parser.php
+++ b/Parser.php
@@ -49,7 +49,7 @@ abstract class Parser
 	{
 		$this->prepare();
 		
-		if (empty($text)) {
+		if ($text !== '0' && empty($text)) {
 			return '';
 		}
 
@@ -74,7 +74,7 @@ abstract class Parser
 	{
 		$this->prepare();
 
-		if (empty($text)) {
+		if ($text !== '0' && empty($text)) {
 			return '';
 		}
 
@@ -167,7 +167,7 @@ abstract class Parser
 		// convert lines to blocks
 		for ($i = 0, $count = count($lines); $i < $count; $i++) {
 			$line = $lines[$i];
-			if (!empty($line) && rtrim($line) !== '') { // skip empty lines
+			if (($line === '0' || !empty($line)) && rtrim($line) !== '') { // skip empty lines
 				// identify a blocks beginning
 				$identified = false;
 				foreach($blockTypes as $blockType) {

--- a/tests/GithubMarkdownTest.php
+++ b/tests/GithubMarkdownTest.php
@@ -54,4 +54,12 @@ class GithubMarkdownTest extends BaseMarkdownTest
 		}
 		return $files;
 	}
+
+	public function testKeepZeroAlive()
+	{
+		$parser = $this->createMarkdown();
+
+		$this->assertEquals("0", $parser->parseParagraph("0"));
+		$this->assertEquals("<p>0</p>\n", $parser->parse("0"));
+	}
 }

--- a/tests/MarkdownTest.php
+++ b/tests/MarkdownTest.php
@@ -34,4 +34,12 @@ class MarkdownTest extends BaseMarkdownTest
 		$this->assertEquals("<p>&amp;</p>\n", $this->createMarkdown()->parse('&'));
 		$this->assertEquals("<p>&lt;</p>\n", $this->createMarkdown()->parse('<'));
 	}
+
+	public function testKeepZeroAlive()
+	{
+		$parser = $this->createMarkdown();
+
+		$this->assertEquals("0", $parser->parseParagraph("0"));
+		$this->assertEquals("<p>0</p>\n", $parser->parse("0"));
+	}
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -41,6 +41,14 @@ class ParserTest extends  \PHPUnit_Framework_TestCase
 		$this->assertEquals('Result is A', $parser->parseParagraph('Result is [abc]'));
 		$this->assertEquals('Result is B', $parser->parseParagraph('Result is [[abc]]'));
 	}
+
+	public function testKeepZeroAlive()
+	{
+		$parser = new TestParser();
+
+		$this->assertEquals("0", $parser->parseParagraph("0"));
+		$this->assertEquals("<p>0</p>\n", $parser->parse("0"));
+	}
 }
 
 class TestParser extends Parser


### PR DESCRIPTION
String "0" should be treated exceptionally when empty() check.