### PR TITLE
Fix PHP fatal error when maximumNestingLevel was reached.

### DIFF
--- a/Parser.php
+++ b/Parser.php
@@ -319,7 +319,7 @@ abstract class Parser
 	{
 		if ($this->_depth >= $this->maximumNestingLevel) {
 			// maximum depth is reached, do not parse input
-			return ['text', $text];
+			return [['text', $text]];
 		}
 		$this->_depth++;
 

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -41,6 +41,21 @@ class ParserTest extends  \PHPUnit_Framework_TestCase
 		$this->assertEquals('Result is A', $parser->parseParagraph('Result is [abc]'));
 		$this->assertEquals('Result is B', $parser->parseParagraph('Result is [[abc]]'));
 	}
+
+	public function testMaxNestingLevel()
+	{
+		$parser = new TestParser();
+		$parser->markers = [
+			'[' => 'parseMarkerC',
+		];
+
+		$parser->maximumNestingLevel = 3;
+		$this->assertEquals("(C-a(C-b(C-c)))", $parser->parseParagraph('[a[b[c]]]'));
+		$parser->maximumNestingLevel = 2;
+		$this->assertEquals("(C-a(C-b[c]))", $parser->parseParagraph('[a[b[c]]]'));
+		$parser->maximumNestingLevel = 1;
+		$this->assertEquals("(C-a[b[c]])", $parser->parseParagraph('[a[b[c]]]'));
+	}
 }
 
 class TestParser extends Parser
@@ -60,5 +75,12 @@ class TestParser extends Parser
 	protected function parseMarkerB($text)
 	{
 		return [['text', 'B'], strrpos($text, ']') + 1];
+	}
+
+	protected function parseMarkerC($text)
+	{
+		$terminatingMarkerPos = strrpos($text, ']');
+		$inside = $this->parseInline(substr($text, 1, $terminatingMarkerPos - 1));
+		return [['text', '(C-' . $this->renderAbsy($inside) . ')'], $terminatingMarkerPos + 1];
 	}
 }


### PR DESCRIPTION
When I created very deep block with Markdown syntax, I got a PHP error like as:

```
PHP Fatal error:  Call to undefined method cebe\markdown\tests\TestParser::rendert() in /.../Parser.php on line 202
```

`t` of `::rendert()` is assumed as the first letter of 'text'. It comes from `return ['text', $text];`. But right block structure is `[['text', $text]]`, I think. Is'nt so?