### PR TITLE
Fix backslash escape to work inside of other markers.

### DIFF
--- a/GithubMarkdown.php
+++ b/GithubMarkdown.php
@@ -97,7 +97,7 @@ class GithubMarkdown extends Markdown
 	{
 		if ($this->enableNewlines) {
 			$br = $this->html5 ? "<br>\n" : "<br />\n";
-			return strtr($text[1], ["  \n" => $br, "\n" => $br]);
+			return strtr($this->unescape($text[1]), ["  \n" => $br, "\n" => $br]);
 		} else {
 			return parent::renderText($text);
 		}

--- a/Markdown.php
+++ b/Markdown.php
@@ -64,7 +64,6 @@ class Markdown extends Parser
 		'<', '>',
 	];
 
-
 	/**
 	 * @inheritDoc
 	 */
@@ -116,6 +115,6 @@ class Markdown extends Parser
 	 */
 	protected function renderText($text)
 	{
-		return str_replace("  \n", $this->html5 ? "<br>\n" : "<br />\n", $text[1]);
+		return str_replace("  \n", $this->html5 ? "<br>\n" : "<br />\n", $this->unescape($text[1]));
 	}
 }

--- a/Markdown.php
+++ b/Markdown.php
@@ -64,6 +64,7 @@ class Markdown extends Parser
 		'<', '>',
 	];
 
+
 	/**
 	 * @inheritDoc
 	 */

--- a/MarkdownExtra.php
+++ b/MarkdownExtra.php
@@ -131,7 +131,7 @@ class MarkdownExtra extends Markdown
 	{
 		$attributes = $this->renderAttributes($block);
 		return ($this->codeAttributesOnPre ? "<pre$attributes><code>" : "<pre><code$attributes>")
-			. htmlspecialchars($block['content'] . "\n", ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8')
+			. htmlspecialchars($this->unescape($block['content'], true) . "\n", ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8')
 			. "</code></pre>\n";
 	}
 
@@ -227,8 +227,8 @@ class MarkdownExtra extends Markdown
 			}
 		}
 		$attributes = $this->renderAttributes($block);
-		return '<a href="' . htmlspecialchars($block['url'], ENT_COMPAT | ENT_HTML401, 'UTF-8') . '"'
-			. (empty($block['title']) ? '' : ' title="' . htmlspecialchars($block['title'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE, 'UTF-8') . '"')
+		return '<a href="' . htmlspecialchars($this->unescape($block['url']), ENT_COMPAT | ENT_HTML401, 'UTF-8') . '"'
+			. (empty($block['title']) ? '' : ' title="' . htmlspecialchars($this->unescape($block['title']), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE, 'UTF-8') . '"')
 			. $attributes . '>' . $this->renderAbsy($block['text']) . '</a>';
 	}
 
@@ -242,9 +242,9 @@ class MarkdownExtra extends Markdown
 			}
 		}
 		$attributes = $this->renderAttributes($block);
-		return '<img src="' . htmlspecialchars($block['url'], ENT_COMPAT | ENT_HTML401, 'UTF-8') . '"'
+		return '<img src="' . htmlspecialchars($this->unescape($block['url']), ENT_COMPAT | ENT_HTML401, 'UTF-8') . '"'
 			. ' alt="' . htmlspecialchars($block['text'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE, 'UTF-8') . '"'
-			. (empty($block['title']) ? '' : ' title="' . htmlspecialchars($block['title'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE, 'UTF-8') . '"')
+			. (empty($block['title']) ? '' : ' title="' . htmlspecialchars($this->unescape($block['title']), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE, 'UTF-8') . '"')
 			. $attributes . ($this->html5 ? '>' : ' />');
 	}
 }

--- a/Parser.php
+++ b/Parser.php
@@ -97,7 +97,7 @@ abstract class Parser
 		if (empty($this->escapeCharacters)) {
 			return $text;
 		} else {
-			$cs = '[' . preg_quote(implode('', $this->escapeCharacters)) . ']';
+			$cs = '[' . preg_quote(implode('', $this->escapeCharacters), '/') . ']';
 			return preg_replace_callback('/\\\\(' . $cs . ')/s', function($matches) {
 				$key = array_search($matches[1], $this->escapeCharacters);
 				return chr(0x1b) . $key .  chr(0x1b);

--- a/Parser.php
+++ b/Parser.php
@@ -25,17 +25,16 @@ abstract class Parser
 	 * TODO remove in favor of absy
 	 */
 	protected $context = [];
+
 	/**
 	 * @var array these are "escapeable" characters. When using one of these prefixed with a
 	 * backslash, the character will be outputted without the backslash and is not interpreted
 	 * as markdown.
 	 */
 	protected $escapeCharacters = [
-		'\\', // backslash
 	];
 
 	private $_depth = 0;
-
 
 	/**
 	 * Parses the given text considering the full language.
@@ -47,6 +46,7 @@ abstract class Parser
 	 */
 	public function parse($text)
 	{
+		$text = $this->escape($text);
 		$this->prepare();
 
 		if (ltrim($text) === '') {
@@ -72,6 +72,7 @@ abstract class Parser
 	 */
 	public function parseParagraph($text)
 	{
+		$text = $this->escape($text);
 		$this->prepare();
 
 		if (ltrim($text) === '') {
@@ -87,6 +88,29 @@ abstract class Parser
 
 		$this->cleanup();
 		return $markup;
+	}
+
+	protected function escape($text)
+	{
+		if (empty($this->escapeCharacters)) {
+			return $text;
+		} else {
+			$cs = '[' . preg_quote(implode('', $this->escapeCharacters)) . ']';
+			return preg_replace_callback('/\\\\(' . $cs . ')/s', function($matches) {
+				$key = array_search($matches[1], $this->escapeCharacters);
+				return chr(0x1b) . $key .  chr(0x1b);
+			}, $text);
+		}
+	}
+
+	protected function unescape($text, $includesEscapeCharacter=false)
+	{
+		$text = preg_replace_callback('/\\x1b(.+?)\\x1b/', function($matches) use($includesEscapeCharacter) {
+			$key = $matches[1];
+			$c = isset($this->escapeCharacters[$key]) ? $this->escapeCharacters[$key] : '';
+			return ($includesEscapeCharacter ? '\\' : '') . $c;
+		}, $text);
+		return $text;
 	}
 
 	/**
@@ -365,24 +389,12 @@ abstract class Parser
 	}
 
 	/**
-	 * Parses escaped special characters.
-	 * @marker \
-	 */
-	protected function parseEscape($text)
-	{
-		if (isset($text[1]) && in_array($text[1], $this->escapeCharacters)) {
-			return [['text', $text[1]], 2];
-		}
-		return [['text', $text[0]], 1];
-	}
-
-	/**
 	 * This function renders plain text sections in the markdown text.
 	 * It can be used to work on normal text sections for example to highlight keywords or
 	 * do special escaping.
 	 */
 	protected function renderText($block)
 	{
-		return $block[1];
+		return $this->unescape($block[1]);
 	}
 }

--- a/Parser.php
+++ b/Parser.php
@@ -32,9 +32,11 @@ abstract class Parser
 	 * as markdown.
 	 */
 	protected $escapeCharacters = [
+		'\\', // backslash
 	];
 
 	private $_depth = 0;
+
 
 	/**
 	 * Parses the given text considering the full language.

--- a/block/CodeTrait.php
+++ b/block/CodeTrait.php
@@ -61,6 +61,6 @@ trait CodeTrait
 	protected function renderCode($block)
 	{
 		$class = isset($block['language']) ? ' class="language-' . $block['language'] . '"' : '';
-		return "<pre><code$class>" . htmlspecialchars($block['content'] . "\n", ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8') . "</code></pre>\n";
+		return "<pre><code$class>" . htmlspecialchars($this->unescape($block['content'], true) . "\n", ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8') . "</code></pre>\n";
 	}
 }

--- a/block/HtmlTrait.php
+++ b/block/HtmlTrait.php
@@ -114,7 +114,7 @@ trait HtmlTrait
 	 */
 	protected function renderHtml($block)
 	{
-		return $block['content'] . "\n";
+		return $this->unescape($block['content'], true) . "\n";
 	}
 
 	/**
@@ -136,7 +136,7 @@ trait HtmlTrait
 	 */
 	protected function renderInlineHtml($block)
 	{
-		return $block[1];
+		return $this->unescape($block[1], true);
 	}
 
 	/**

--- a/inline/CodeTrait.php
+++ b/inline/CodeTrait.php
@@ -40,6 +40,6 @@ trait CodeTrait
 
 	protected function renderInlineCode($block)
 	{
-		return '<code>' . htmlspecialchars($block[1], ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</code>';
+		return '<code>' . htmlspecialchars($this->unescape($block[1], true), ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8') . '</code>';
 	}
 }

--- a/inline/LinkTrait.php
+++ b/inline/LinkTrait.php
@@ -193,14 +193,14 @@ REGEXP;
 
 	protected function renderEmail($block)
 	{
-		$email = htmlspecialchars($block[1], ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
+		$email = htmlspecialchars($this->unescape($block[1]), ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
 		return "<a href=\"mailto:$email\">$email</a>";
 	}
 
 	protected function renderUrl($block)
 	{
-		$url = htmlspecialchars($block[1], ENT_COMPAT | ENT_HTML401, 'UTF-8');
-		$text = htmlspecialchars(urldecode($block[1]), ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
+		$url = htmlspecialchars($this->unescape($block[1]), ENT_COMPAT | ENT_HTML401, 'UTF-8');
+		$text = htmlspecialchars(urldecode($this->unescape($block[1])), ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
 		return "<a href=\"$url\">$text</a>";
 	}
 
@@ -219,11 +219,11 @@ REGEXP;
 			if (($ref = $this->lookupReference($block['refkey'])) !== false) {
 				$block = array_merge($block, $ref);
 			} else {
-				return $block['orig'];
+				return $this->unescape($block['orig']);
 			}
 		}
-		return '<a href="' . htmlspecialchars($block['url'], ENT_COMPAT | ENT_HTML401, 'UTF-8') . '"'
-			. (empty($block['title']) ? '' : ' title="' . htmlspecialchars($block['title'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE, 'UTF-8') . '"')
+		return '<a href="' . htmlspecialchars($this->unescape($block['url']), ENT_COMPAT | ENT_HTML401, 'UTF-8') . '"'
+			. (empty($block['title']) ? '' : ' title="' . htmlspecialchars($this->unescape($block['title']), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE, 'UTF-8') . '"')
 			. '>' . $this->renderAbsy($block['text']) . '</a>';
 	}
 
@@ -233,12 +233,12 @@ REGEXP;
 			if (($ref = $this->lookupReference($block['refkey'])) !== false) {
 				$block = array_merge($block, $ref);
 			} else {
-				return $block['orig'];
+				return $this->unescape($block['orig']);
 			}
 		}
-		return '<img src="' . htmlspecialchars($block['url'], ENT_COMPAT | ENT_HTML401, 'UTF-8') . '"'
-			. ' alt="' . htmlspecialchars($block['text'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE, 'UTF-8') . '"'
-			. (empty($block['title']) ? '' : ' title="' . htmlspecialchars($block['title'], ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE, 'UTF-8') . '"')
+		return '<img src="' . htmlspecialchars($this->unescape($block['url']), ENT_COMPAT | ENT_HTML401, 'UTF-8') . '"'
+			. ' alt="' . htmlspecialchars($this->unescape($block['text']), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE, 'UTF-8') . '"'
+			. (empty($block['title']) ? '' : ' title="' . htmlspecialchars($this->unescape($block['title']), ENT_COMPAT | ENT_HTML401 | ENT_SUBSTITUTE, 'UTF-8') . '"')
 			. ($this->html5 ? '>' : ' />');
 	}
 

--- a/inline/UrlLinkTrait.php
+++ b/inline/UrlLinkTrait.php
@@ -41,8 +41,8 @@ REGEXP;
 
 	protected function renderAutoUrl($block)
 	{
-		$href = htmlspecialchars($block[1], ENT_COMPAT | ENT_HTML401, 'UTF-8');
-		$text = htmlspecialchars(urldecode($block[1]), ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
+		$href = htmlspecialchars($this->unescape($block[1]), ENT_COMPAT | ENT_HTML401, 'UTF-8');
+		$text = htmlspecialchars(urldecode($this->unescape($block[1])), ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
 		return "<a href=\"$href\">$text</a>";
 	}
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -64,13 +64,29 @@ class ParserTest extends  \PHPUnit_Framework_TestCase
 		$this->assertEquals("0", $parser->parseParagraph("0"));
 		$this->assertEquals("<p>0</p>\n", $parser->parse("0"));
 	}
+
+	public function testEscape()
+	{
+		$parser = new TestParser();
+		$parser->markers = [
+			'[' => 'parseMarkerC',
+		];
+
+		$this->assertEquals("[a(C-b)c]", $parser->parseParagraph("\\[a[b]c\\]"));
+		$this->assertEquals("(C-a[b]c)", $parser->parseParagraph("[a\\[b\\]c]"));
+		$this->assertEquals("\\[", $parser->parseParagraph("\\\\\\["));
+	}
 }
 
 class TestParser extends Parser
 {
 	public $markers = [];
 
-	protected function inlineMarkers()
+	protected $escapeCharacters = [
+		'\\', '[', ']'
+	];
+
+    protected function inlineMarkers()
 	{
 		return $this->markers;
 	}

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -86,7 +86,7 @@ class TestParser extends Parser
 		'\\', '[', ']'
 	];
 
-    protected function inlineMarkers()
+	protected function inlineMarkers()
 	{
 		return $this->markers;
 	}

--- a/tests/github-data/issue-38.html
+++ b/tests/github-data/issue-38.html
@@ -1,7 +1,7 @@
 <blockquote><p>some text
 `<code>`
 // some code
-\</code>``</p>
+\`</code>`</p>
 </blockquote>
 <blockquote><p>some text</p>
 <pre><code>// some code

--- a/tests/markdown-data/emphasis.html
+++ b/tests/markdown-data/emphasis.html
@@ -14,5 +14,5 @@ bold</strong></p>
 <p><em>emphasized text</em><strong>strong text</strong></p>
 <p>simple_word_with_underscores</p>
 <p>this is text, <em>this is emph</em> simple_word_with_underscores text again.</p>
-<p><em>em_text</em> <strong>strong__text</strong></p>
-<p><em>em*text</em> <strong>strong**text</strong></p>
+<p><em>em_text</em> <strong>strong__text_</strong></p>
+<p><em>em*text</em> <strong>strong**text*</strong></p>

--- a/tests/markdown-data/emphasis.html
+++ b/tests/markdown-data/emphasis.html
@@ -14,3 +14,5 @@ bold</strong></p>
 <p><em>emphasized text</em><strong>strong text</strong></p>
 <p>simple_word_with_underscores</p>
 <p>this is text, <em>this is emph</em> simple_word_with_underscores text again.</p>
+<p><em>em_text</em> <strong>strong__text</strong></p>
+<p><em>em*text</em> <strong>strong**text</strong></p>

--- a/tests/markdown-data/emphasis.md
+++ b/tests/markdown-data/emphasis.md
@@ -27,3 +27,7 @@ _emphasized text_**strong text**
 simple_word_with_underscores
 
 this is text, _this is emph_ simple_word_with_underscores text again.
+
+_em\_text_ __strong\_\_text__
+
+*em\*text* **strong\*\*text**

--- a/tests/markdown-data/emphasis.md
+++ b/tests/markdown-data/emphasis.md
@@ -28,6 +28,6 @@ simple_word_with_underscores
 
 this is text, _this is emph_ simple_word_with_underscores text again.
 
-_em\_text_ __strong\_\_text__
+_em\_text_ __strong\_\_text\___
 
-*em\*text* **strong\*\*text**
+*em\*text* **strong\*\*text\***


### PR DESCRIPTION
Escape character should not be a syntax but should be preprocessor, I think.

Current implementation converts below:

```
*em\*text*

**strong text\***
```

To:

```
<p><em>em\</em>text*</p>
<p><strong>strong text\</strong>*</p>
```

> <p><em>em\</em>text*</p>
> 
> <p><strong>strong text\</strong>*</p>

I expect they are:

```
<p><em>em*text</em></p>
<p><strong>strong text*</strong></p>
```

> <p><em>em*text</em></p>
> 
> <p><strong>strong text*</strong></p>
