### PR TITLE
Fix table renderer which including default alignment

### DIFF
--- a/block/TableTrait.php
+++ b/block/TableTrait.php
@@ -91,7 +91,8 @@ trait TableTrait
 		$first = true;
 		foreach($block['rows'] as $row) {
 			$this->_tableCellTag = $first ? 'th' : 'td';
-			$align = empty($this->_tableCellAlign[$this->_tableCellCount]) ? '' : ' align="' . $this->_tableCellAlign[$this->_tableCellCount++] . '"';
+			$align = empty($this->_tableCellAlign[$this->_tableCellCount]) ? '' : ' align="' . $this->_tableCellAlign[$this->_tableCellCount] . '"';
+			$this->_tableCellCount++;
 			$tds = "<$this->_tableCellTag$align>" . trim($this->renderAbsy($this->parseInline($row))) . "</$this->_tableCellTag>"; // TODO move this to the consume step
 			$content .= "<tr>$tds</tr>\n";
 			if ($first) {
@@ -109,7 +110,8 @@ trait TableTrait
 	protected function parseTd($markdown)
 	{
 		if (isset($this->context[1]) && $this->context[1] === 'table') {
-			$align = empty($this->_tableCellAlign[$this->_tableCellCount]) ? '' : ' align="' . $this->_tableCellAlign[$this->_tableCellCount++] . '"';
+			$align = empty($this->_tableCellAlign[$this->_tableCellCount]) ? '' : ' align="' . $this->_tableCellAlign[$this->_tableCellCount] . '"';
+			$this->_tableCellCount++;
 			return [['text', "</$this->_tableCellTag><$this->_tableCellTag$align>"], isset($markdown[1]) && $markdown[1] === ' ' ? 2 : 1]; // TODO make a absy node
 		}
 		return [['text', $markdown[0]], 1];

--- a/tests/extra-data/tables.html
+++ b/tests/extra-data/tables.html
@@ -37,12 +37,12 @@
 </table>
 <table>
 <thead>
-<tr><th align="left">Left-Aligned  </th><th align="center">Center Aligned  </th><th align="right">Right Aligned</th></tr>
+<tr><th>Default-Align </th><th align="left">Left-Aligned  </th><th align="center">Center Aligned  </th><th align="right">Right Aligned</th></tr>
 </thead>
 <tbody>
-<tr><td align="left">col 3 is      </td><td align="center">some wordy text </td><td align="right">$1600</td></tr>
-<tr><td align="left">col 2 is      </td><td align="center">centered        </td><td align="right">  $12</td></tr>
-<tr><td align="left">zebra stripes </td><td align="center">are neat        </td><td align="right">   $1</td></tr>
+<tr><td>1             </td><td align="left">col 3 is      </td><td align="center">some wordy text </td><td align="right">$1600</td></tr>
+<tr><td>2             </td><td align="left">col 2 is      </td><td align="center">centered        </td><td align="right">  $12</td></tr>
+<tr><td>3             </td><td align="left">zebra stripes </td><td align="center">are neat        </td><td align="right">   $1</td></tr>
 </tbody>
 </table>
 <table>

--- a/tests/extra-data/tables.md
+++ b/tests/extra-data/tables.md
@@ -21,11 +21,11 @@ Content Cell  | Content Cell
 | Help      | **Display the** help window.|
 | Close     | _Closes_ a window     |
 
-| Left-Aligned  | Center Aligned  | Right Aligned |
-| :------------ |:---------------:| -----:|
-| col 3 is      | some wordy text | $1600 |
-| col 2 is      | centered        |   $12 |
-| zebra stripes | are neat        |    $1 |
+| Default-Align | Left-Aligned  | Center Aligned  | Right Aligned |
+| ------------- | :------------ |:---------------:| -----:|
+| 1             | col 3 is      | some wordy text | $1600 |
+| 2             | col 2 is      | centered        |   $12 |
+| 3             | zebra stripes | are neat        |    $1 |
 
 
 Simple | Table

--- a/tests/github-data/tables.html
+++ b/tests/github-data/tables.html
@@ -37,12 +37,12 @@
 </table>
 <table>
 <thead>
-<tr><th align="left">Left-Aligned  </th><th align="center">Center Aligned  </th><th align="right">Right Aligned</th></tr>
+<tr><th>Default-Align </th><th align="left">Left-Aligned  </th><th align="center">Center Aligned  </th><th align="right">Right Aligned</th></tr>
 </thead>
 <tbody>
-<tr><td align="left">col 3 is      </td><td align="center">some wordy text </td><td align="right">$1600</td></tr>
-<tr><td align="left">col 2 is      </td><td align="center">centered        </td><td align="right">  $12</td></tr>
-<tr><td align="left">zebra stripes </td><td align="center">are neat        </td><td align="right">   $1</td></tr>
+<tr><td>1             </td><td align="left">col 3 is      </td><td align="center">some wordy text </td><td align="right">$1600</td></tr>
+<tr><td>2             </td><td align="left">col 2 is      </td><td align="center">centered        </td><td align="right">  $12</td></tr>
+<tr><td>3             </td><td align="left">zebra stripes </td><td align="center">are neat        </td><td align="right">   $1</td></tr>
 </tbody>
 </table>
 <table>

--- a/tests/github-data/tables.md
+++ b/tests/github-data/tables.md
@@ -21,11 +21,11 @@ Content Cell  | Content Cell
 | Help      | **Display the** help window.|
 | Close     | _Closes_ a window     |
 
-| Left-Aligned  | Center Aligned  | Right Aligned |
-| :------------ |:---------------:| -----:|
-| col 3 is      | some wordy text | $1600 |
-| col 2 is      | centered        |   $12 |
-| zebra stripes | are neat        |    $1 |
+| Default-Align | Left-Aligned  | Center Aligned  | Right Aligned |
+| ------------- | :------------ |:---------------:| -----:|
+| 1             | col 3 is      | some wordy text | $1600 |
+| 2             | col 2 is      | centered        |   $12 |
+| 3             | zebra stripes | are neat        |    $1 |
 
 
 Simple | Table


### PR DESCRIPTION
There is table alignment bug, when mixed alignments specified.
`?:` operator never evaluates the unmatched case.