### PR TITLE
Use given encoded url if decoded URL text looks insecure

### DIFF
--- a/inline/LinkTrait.php
+++ b/inline/LinkTrait.php
@@ -200,7 +200,9 @@ REGEXP;
 	protected function renderUrl($block)
 	{
 		$url = htmlspecialchars($block[1], ENT_COMPAT | ENT_HTML401, 'UTF-8');
-		$text = htmlspecialchars(urldecode($block[1]), ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
+		$decodedUrl = urldecode($block[1]);
+		$secureUrlText = preg_match('//u', $decodedUrl) ? $decodedUrl : $block[1];
+		$text = htmlspecialchars($secureUrlText, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
 		return "<a href=\"$url\">$text</a>";
 	}
 

--- a/inline/UrlLinkTrait.php
+++ b/inline/UrlLinkTrait.php
@@ -42,7 +42,9 @@ REGEXP;
 	protected function renderAutoUrl($block)
 	{
 		$href = htmlspecialchars($block[1], ENT_COMPAT | ENT_HTML401, 'UTF-8');
-		$text = htmlspecialchars(urldecode($block[1]), ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
+		$decodedUrl = urldecode($block[1]);
+		$secureUrlText = preg_match('//u', $decodedUrl) ? $decodedUrl : $block[1];
+		$text = htmlspecialchars($secureUrlText, ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8');
 		return "<a href=\"$href\">$text</a>";
 	}
 }

--- a/tests/GithubMarkdownTest.php
+++ b/tests/GithubMarkdownTest.php
@@ -62,4 +62,19 @@ class GithubMarkdownTest extends BaseMarkdownTest
 		$this->assertEquals("0", $parser->parseParagraph("0"));
 		$this->assertEquals("<p>0</p>\n", $parser->parse("0"));
 	}
+
+	public function testAutoLinkLabelingWithEncodedUrl()
+	{
+		$parser = $this->createMarkdown();
+
+		$utfText = "\xe3\x81\x82\xe3\x81\x84\xe3\x81\x86\xe3\x81\x88\xe3\x81\x8a";
+		$utfNaturalUrl = "http://example.com/" . $utfText;
+		$utfEncodedUrl = "http://example.com/" . urlencode($utfText);
+		$eucEncodedUrl = "http://example.com/" . urlencode(mb_convert_encoding($utfText, 'EUC-JP', 'UTF-8'));
+
+		$this->assertStringEndsWith(">{$utfNaturalUrl}</a>", $parser->parseParagraph($utfNaturalUrl), "Natural UTF-8 URL needs no conversion.");
+		$this->assertStringEndsWith(">{$utfNaturalUrl}</a>", $parser->parseParagraph($utfEncodedUrl), "Encoded UTF-8 URL will be converted to readable format.");
+		$this->assertStringEndsWith(">{$eucEncodedUrl}</a>", $parser->parseParagraph($eucEncodedUrl), "Non UTF-8 URL should never be converted.");
+		// See: \cebe\markdown\inline\UrlLinkTrait::renderAutoUrl
+	}
 }

--- a/tests/MarkdownTest.php
+++ b/tests/MarkdownTest.php
@@ -42,4 +42,19 @@ class MarkdownTest extends BaseMarkdownTest
 		$this->assertEquals("0", $parser->parseParagraph("0"));
 		$this->assertEquals("<p>0</p>\n", $parser->parse("0"));
 	}
+
+	public function testAutoLinkLabelingWithEncodedUrl()
+	{
+		$parser = $this->createMarkdown();
+
+		$utfText = "\xe3\x81\x82\xe3\x81\x84\xe3\x81\x86\xe3\x81\x88\xe3\x81\x8a";
+		$utfNaturalUrl = "http://example.com/" . $utfText;
+		$utfEncodedUrl = "http://example.com/" . urlencode($utfText);
+		$eucEncodedUrl = "http://example.com/" . urlencode(mb_convert_encoding($utfText, 'EUC-JP', 'UTF-8'));
+
+		$this->assertStringEndsWith(">{$utfNaturalUrl}</a>", $parser->parseParagraph("<{$utfNaturalUrl}>"), "Natural UTF-8 URL needs no conversion.");
+		$this->assertStringEndsWith(">{$utfNaturalUrl}</a>", $parser->parseParagraph("<{$utfEncodedUrl}>"), "Encoded UTF-8 URL will be converted to readable format.");
+		$this->assertStringEndsWith(">{$eucEncodedUrl}</a>", $parser->parseParagraph("<{$eucEncodedUrl}>"), "Non UTF-8 URL should never be converted.");
+		// See: \cebe\markdown\inline\LinkTrait::renderUrl
+	}
 }


### PR DESCRIPTION
I suggest to cancel URL decoding when non UTF-8 encoding detected, instead raw encoded URL should be displayed for security.

I tested auto-link using Japanese basic characters:

```
1. http://example.com/あいうえお
2. http://example.com/%E3%81%82%E3%81%84%E3%81%86%E3%81%88%E3%81%8A
3. http://example.com/%A4%A2%A4%A4%A4%A6%A4%A8%A4%AA
```

1 contains UTF-8 text in URL.
2 is url encoded version of 1.
3 is url encoded string but non UTF-8 charset (EUC-JP) version.

![cebe-md-v](https://cloud.githubusercontent.com/assets/403893/18865796/fbede852-84d7-11e6-9ac5-ca5221d40eca.png)

3 displays unexpected broken text which might have some insecure code. It should be displayed just as `http://example.com/%A4%A2%A4%A4%A4%A6%A4%A8%A4%AA` in UTF-8 web page.

- - -

For comparison, GitHub shows URLs without decoding.

![gfm](https://cloud.githubusercontent.com/assets/403893/18865164/e0097622-84d4-11e6-9b21-725a5e55b426.png)

This way looks safer but I don't like because it looks not suit for casual use in domestic languages.