### PR TITLE
Fix paragraph breaking condition

### DIFF
--- a/GithubMarkdown.php
+++ b/GithubMarkdown.php
@@ -71,7 +71,8 @@ class GithubMarkdown extends Markdown
 					$this->identifyFencedCode($line, $lines, $i) ||
 					$this->identifyUl($line, $lines, $i) ||
 					$this->identifyOl($line, $lines, $i) ||
-					$this->identifyHr($line, $lines, $i)
+					$this->identifyHr($line, $lines, $i) ||
+					$this->identifyHtml($line, $lines, $i)
 				)
 				|| $this->identifyHeadline($line, $lines, $i))
 			{

--- a/Markdown.php
+++ b/Markdown.php
@@ -92,9 +92,17 @@ class Markdown extends Parser
 				break;
 			}
 
-			if ($line === '' || ltrim($line) === '' || $this->identifyHeadline($line, $lines, $i)) {
+			if (
+				$line === '' ||
+				ltrim($line) === '' ||
+				!ctype_alpha($line[0]) && (
+					$this->identifyQuote($line, $lines, $i) ||
+					$this->identifyHr($line, $lines, $i) ||
+					$this->identifyHtml($line, $lines, $i)
+				)
+				|| $this->identifyHeadline($line, $lines, $i)) {
 				break;
-			} elseif ($line[0] === "\t" || $line[0] === " " && strncmp($line, '    ', 4) === 0) {
+			} elseif ($this->identifyCode($line, $lines, $i)) {
 				// possible beginning of a code block
 				// but check for continued inline HTML
 				// e.g. <img src="file.jpg"

--- a/tests/github-data/dense-block-markers.html
+++ b/tests/github-data/dense-block-markers.html
@@ -50,3 +50,10 @@ quote</p>
 <ul>
 <li>17-Feb-2013 re-design</li>
 </ul>
+<p>paragraph</p>
+<blockquote><p>quote</p>
+</blockquote>
+<p>paragraph</p>
+<hr />
+<p>paragraph</p>
+<div>html block</div>

--- a/tests/github-data/dense-block-markers.md
+++ b/tests/github-data/dense-block-markers.md
@@ -54,3 +54,12 @@ headline2
 ----
 ## changelog 2
 * 17-Feb-2013 re-design
+
+paragraph
+> quote
+
+paragraph
+- - -
+
+paragraph
+<div>html block</div>

--- a/tests/markdown-data/dense-block-markers.html
+++ b/tests/markdown-data/dense-block-markers.html
@@ -48,3 +48,10 @@ quote</p>
 <ul>
 <li>17-Feb-2013 re-design</li>
 </ul>
+<p>paragraph</p>
+<blockquote><p>quote</p>
+</blockquote>
+<p>paragraph</p>
+<hr />
+<p>paragraph</p>
+<div>html block</div>

--- a/tests/markdown-data/dense-block-markers.md
+++ b/tests/markdown-data/dense-block-markers.md
@@ -54,3 +54,12 @@ headline2
 ----
 ## changelog 2
 * 17-Feb-2013 re-design
+
+paragraph
+> quote
+
+paragraph
+- - -
+
+paragraph
+<div>html block</div>

--- a/tests/markdown-data/images.html
+++ b/tests/markdown-data/images.html
@@ -2,9 +2,9 @@
 <img src="https://secure.travis-ci.org/cebe/markdown.png" alt="Build Status" title="test1" /></p>
 <p>Here is an image tag: <img src="https://poser.pugx.org/cebe/markdown/downloads.png" alt="Total Downloads" />.</p>
 <p>Images inside of links:
-<a href="https://packagist.org/packages/cebe/markdown"><img src="https://poser.pugx.org/cebe/markdown/downloads.png" alt="Total Downloads" /></a>
+<a href="https://packagist.org/packages/cebe/markdown"><img src="https://poser.pugx.org/cebe/markdown/downloads.png" alt="Total Downloads" /></a></p>
 <!-- [![Scrutinizer Quality Score](https://scrutinizer-ci.com/g/cebe/markdown/badges/quality-score.png?s=17448ca4d140429fd687c58ff747baeb6568d528)](https://scrutinizer-ci.com/g/cebe/markdown/) -->
-<a href="http://travis-ci.org/cebe/markdown"><img src="https://secure.travis-ci.org/cebe/markdown.png" alt="Build Status" title="test2" /></a>
+<p><a href="http://travis-ci.org/cebe/markdown"><img src="https://secure.travis-ci.org/cebe/markdown.png" alt="Build Status" title="test2" /></a>
 <a href="http://travis-ci.org/cebe/markdown" title="test4"><img src="https://secure.travis-ci.org/cebe/markdown.png" alt="Build Status" title="test3" /></a></p>
 <p>This is not an image: ![[ :-)</p>
 <p>This is not an image: ![[ :-)]]</p>


### PR DESCRIPTION
Quote, HR and HTML are independent blocks even if not placed empty lines before them.

For example:

```
paragraph
> quote

paragraph
- - -

paragraph
<div>html block</div>
```

I expected to:

```
<p>paragraph</p>
<blockquote>
<p>quote</p>
</blockquote>
<p>paragraph</p>
<hr />
<p>paragraph</p>
<div>html block</div>
```

But actual:

```
<p>paragraph
&gt; quote</p>
<p>paragraph
- - -</p>
<p>paragraph
<div>html block</div></p>
```

Though even traditional markdown (https://daringfireball.net/projects/markdown/dingus) converts dense list block:

```
paragraph
- 1
- 2
```

to

```
<p>paragraph
- 1
- 2</p>
```

It is list specific behavior, but other blocks can be independent. 