### PR TITLE
修复：已经存在的实体会被二次转义

### DIFF
--- a/block/CodeTrait.php
+++ b/block/CodeTrait.php
@@ -61,6 +61,6 @@ trait CodeTrait
 	protected function renderCode($block)
 	{
 		$class = isset($block['language']) ? ' class="language-' . $block['language'] . '"' : '';
-		return "<pre><code$class>" . htmlspecialchars($block['content'] . "\n", ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8') . "</code></pre>\n";
+		return "<pre><code$class>" . htmlspecialchars($block['content'] . "\n", ENT_NOQUOTES | ENT_SUBSTITUTE, 'UTF-8', false) . "</code></pre>\n";
 	}
 }


### PR DESCRIPTION
htmlspecialchars() 传递最后一个参数，使已经存在的实体不再二次转义
```
&lt;
```
以上的代码中，`&`符号会再次被转义成 `&amp;`
当传递了最后一个参数为`false`时，会把`&lt;`看成一个整体，不会仅仅把`&`转义。
在此多有得罪了，谢谢您宝贵的时间！