### PR TITLE
Move table row parse to consume function

### DIFF
--- a/tests/extra-data/tables.html
+++ b/tests/extra-data/tables.html
@@ -1,89 +1,89 @@
 <h2>Tables</h2>
 <table>
 <thead>
-<tr><th>First Header  </th><th>Second Header</th></tr>
+<tr><th>First Header</th><th>Second Header</th></tr>
 </thead>
 <tbody>
-<tr><td>Content Cell  </td><td>Content Cell</td></tr>
-<tr><td>Content Cell  </td><td>Content Cell</td></tr>
+<tr><td>Content Cell</td><td>Content Cell</td></tr>
+<tr><td>Content Cell</td><td>Content Cell</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th>First Header  </th><th>Second Header</th></tr>
+<tr><th>First Header</th><th>Second Header</th></tr>
 </thead>
 <tbody>
-<tr><td>Content Cell  </td><td>Content Cell</td></tr>
-<tr><td>Content Cell  </td><td>Content Cell</td></tr>
+<tr><td>Content Cell</td><td>Content Cell</td></tr>
+<tr><td>Content Cell</td><td>Content Cell</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th>Name </th><th>Description</th></tr>
+<tr><th>Name</th><th>Description</th></tr>
 </thead>
 <tbody>
-<tr><td>Help      </td><td>Display the help window.</td></tr>
-<tr><td>Close     </td><td>Closes a window</td></tr>
+<tr><td>Help</td><td>Display the help window.</td></tr>
+<tr><td>Close</td><td>Closes a window</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th>Name </th><th>Description</th></tr>
+<tr><th>Name</th><th>Description</th></tr>
 </thead>
 <tbody>
-<tr><td>Help      </td><td><strong>Display the</strong> help window.</td></tr>
-<tr><td>Close     </td><td><em>Closes</em> a window</td></tr>
+<tr><td>Help</td><td><strong>Display the</strong> help window.</td></tr>
+<tr><td>Close</td><td><em>Closes</em> a window</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th>Default-Align </th><th align="left">Left-Aligned  </th><th align="center">Center Aligned  </th><th align="right">Right Aligned</th></tr>
+<tr><th>Default-Align</th><th align="left">Left-Aligned</th><th align="center">Center Aligned</th><th align="right">Right Aligned</th></tr>
 </thead>
 <tbody>
-<tr><td>1             </td><td align="left">col 3 is      </td><td align="center">some wordy text </td><td align="right">$1600</td></tr>
-<tr><td>2             </td><td align="left">col 2 is      </td><td align="center">centered        </td><td align="right">  $12</td></tr>
-<tr><td>3             </td><td align="left">zebra stripes </td><td align="center">are neat        </td><td align="right">   $1</td></tr>
+<tr><td>1</td><td align="left">col 3 is</td><td align="center">some wordy text</td><td align="right">$1600</td></tr>
+<tr><td>2</td><td align="left">col 2 is</td><td align="center">centered</td><td align="right">$12</td></tr>
+<tr><td>3</td><td align="left">zebra stripes</td><td align="center">are neat</td><td align="right">$1</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th>Simple </th><th>Table</th></tr>
+<tr><th>Simple</th><th>Table</th></tr>
 </thead>
 <tbody>
-<tr><td>1      </td><td>2</td></tr>
-<tr><td>3      </td><td>4</td></tr>
+<tr><td>1</td><td>2</td></tr>
+<tr><td>3</td><td>4</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th>Simple </th><th>Table</th></tr>
+<tr><th>Simple</th><th>Table</th></tr>
 </thead>
 <tbody>
-<tr><td>1      </td><td>2</td></tr>
-<tr><td>3      </td><td>4</td></tr>
-<tr><td>3      </td><td>4     |</td></tr>
-<tr><td>3      </td><td>4    \</td></tr>
+<tr><td>1</td><td>2</td></tr>
+<tr><td>3</td><td>4</td></tr>
+<tr><td>3</td><td>4     |</td></tr>
+<tr><td>3</td><td>4    \</td></tr>
 </tbody>
 </table>
 <p>Check https://github.com/erusev/parsedown/issues/184 for the following:</p>
 <table>
 <thead>
-<tr><th>Foo </th><th>Bar </th><th>State</th></tr>
+<tr><th>Foo</th><th>Bar</th><th>State</th></tr>
 </thead>
 <tbody>
-<tr><td><code>Code | Pipe</code> </td><td>Broken </td><td>Blank</td></tr>
-<tr><td><code>Escaped Code \| Pipe</code> </td><td>Broken </td><td>Blank</td></tr>
-<tr><td>Escaped | Pipe </td><td>Broken </td><td>Blank</td></tr>
-<tr><td>Escaped \</td><td>Pipe </td><td>Broken </td><td>Blank</td></tr>
-<tr><td>Escaped \ </td><td>Pipe </td><td>Broken </td><td>Blank</td></tr>
+<tr><td><code>Code | Pipe</code></td><td>Broken</td><td>Blank</td></tr>
+<tr><td><code>Escaped Code \| Pipe</code></td><td>Broken</td><td>Blank</td></tr>
+<tr><td>Escaped | Pipe</td><td>Broken</td><td>Blank</td></tr>
+<tr><td>Escaped \</td><td>Pipe</td><td>Broken</td><td>Blank</td></tr>
+<tr><td>Escaped \</td><td>Pipe</td><td>Broken</td><td>Blank</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th align="left">Simple </th><th>Table</th></tr>
+<tr><th align="left">Simple</th><th>Table</th></tr>
 </thead>
 <tbody>
-<tr><td align="left">3      </td><td>4</td></tr>
+<tr><td align="left">3</td><td>4</td></tr>
 </tbody>
 </table>
 <p>3      | 4</p>

--- a/tests/github-data/tables.html
+++ b/tests/github-data/tables.html
@@ -1,102 +1,102 @@
 <h2>Tables</h2>
 <table>
 <thead>
-<tr><th>First Header  </th><th>Second Header</th></tr>
+<tr><th>First Header</th><th>Second Header</th></tr>
 </thead>
 <tbody>
-<tr><td>Content Cell  </td><td>Content Cell</td></tr>
-<tr><td>Content Cell  </td><td>Content Cell</td></tr>
+<tr><td>Content Cell</td><td>Content Cell</td></tr>
+<tr><td>Content Cell</td><td>Content Cell</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th>First Header  </th><th>Second Header</th></tr>
+<tr><th>First Header</th><th>Second Header</th></tr>
 </thead>
 <tbody>
-<tr><td>Content Cell  </td><td>Content Cell</td></tr>
-<tr><td>Content Cell  </td><td>Content Cell</td></tr>
+<tr><td>Content Cell</td><td>Content Cell</td></tr>
+<tr><td>Content Cell</td><td>Content Cell</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th>Name </th><th>Description</th></tr>
+<tr><th>Name</th><th>Description</th></tr>
 </thead>
 <tbody>
-<tr><td>Help      </td><td>Display the help window.</td></tr>
-<tr><td>Close     </td><td>Closes a window</td></tr>
+<tr><td>Help</td><td>Display the help window.</td></tr>
+<tr><td>Close</td><td>Closes a window</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th>Name </th><th>Description</th></tr>
+<tr><th>Name</th><th>Description</th></tr>
 </thead>
 <tbody>
-<tr><td>Help      </td><td><strong>Display the</strong> help window.</td></tr>
-<tr><td>Close     </td><td><em>Closes</em> a window</td></tr>
+<tr><td>Help</td><td><strong>Display the</strong> help window.</td></tr>
+<tr><td>Close</td><td><em>Closes</em> a window</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th>Default-Align </th><th align="left">Left-Aligned  </th><th align="center">Center Aligned  </th><th align="right">Right Aligned</th></tr>
+<tr><th>Default-Align</th><th align="left">Left-Aligned</th><th align="center">Center Aligned</th><th align="right">Right Aligned</th></tr>
 </thead>
 <tbody>
-<tr><td>1             </td><td align="left">col 3 is      </td><td align="center">some wordy text </td><td align="right">$1600</td></tr>
-<tr><td>2             </td><td align="left">col 2 is      </td><td align="center">centered        </td><td align="right">  $12</td></tr>
-<tr><td>3             </td><td align="left">zebra stripes </td><td align="center">are neat        </td><td align="right">   $1</td></tr>
+<tr><td>1</td><td align="left">col 3 is</td><td align="center">some wordy text</td><td align="right">$1600</td></tr>
+<tr><td>2</td><td align="left">col 2 is</td><td align="center">centered</td><td align="right">$12</td></tr>
+<tr><td>3</td><td align="left">zebra stripes</td><td align="center">are neat</td><td align="right">$1</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th>Simple </th><th>Table</th></tr>
+<tr><th>Simple</th><th>Table</th></tr>
 </thead>
 <tbody>
-<tr><td>1      </td><td>2</td></tr>
-<tr><td>3      </td><td>4</td></tr>
+<tr><td>1</td><td>2</td></tr>
+<tr><td>3</td><td>4</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th>Simple </th><th>Table</th></tr>
+<tr><th>Simple</th><th>Table</th></tr>
 </thead>
 <tbody>
-<tr><td>1      </td><td>2</td></tr>
-<tr><td>3      </td><td>4</td></tr>
-<tr><td>3      </td><td>4     |</td></tr>
-<tr><td>3      </td><td>4    \</td></tr>
+<tr><td>1</td><td>2</td></tr>
+<tr><td>3</td><td>4</td></tr>
+<tr><td>3</td><td>4     |</td></tr>
+<tr><td>3</td><td>4    \</td></tr>
 </tbody>
 </table>
 <p>Check <a href="https://github.com/erusev/parsedown/issues/184">https://github.com/erusev/parsedown/issues/184</a> for the following:</p>
 <table>
 <thead>
-<tr><th>Foo </th><th>Bar </th><th>State</th></tr>
+<tr><th>Foo</th><th>Bar</th><th>State</th></tr>
 </thead>
 <tbody>
-<tr><td><code>Code | Pipe</code> </td><td>Broken </td><td>Blank</td></tr>
-<tr><td><code>Escaped Code \| Pipe</code> </td><td>Broken </td><td>Blank</td></tr>
-<tr><td>Escaped | Pipe </td><td>Broken </td><td>Blank</td></tr>
-<tr><td>Escaped \</td><td>Pipe </td><td>Broken </td><td>Blank</td></tr>
-<tr><td>Escaped \ </td><td>Pipe </td><td>Broken </td><td>Blank</td></tr>
+<tr><td><code>Code | Pipe</code></td><td>Broken</td><td>Blank</td></tr>
+<tr><td><code>Escaped Code \| Pipe</code></td><td>Broken</td><td>Blank</td></tr>
+<tr><td>Escaped | Pipe</td><td>Broken</td><td>Blank</td></tr>
+<tr><td>Escaped \</td><td>Pipe</td><td>Broken</td><td>Blank</td></tr>
+<tr><td>Escaped \</td><td>Pipe</td><td>Broken</td><td>Blank</td></tr>
 </tbody>
 </table>
 <table>
 <thead>
-<tr><th align="left">Simple </th><th>Table</th></tr>
+<tr><th align="left">Simple</th><th>Table</th></tr>
 </thead>
 <tbody>
-<tr><td align="left">3      </td><td>4</td></tr>
+<tr><td align="left">3</td><td>4</td></tr>
 </tbody>
 </table>
 <p>3      | 4</p>
 <table>
 <thead>
-<tr><th>Table </th><th>With </th><th>Empty </th><th>Cells</th></tr>
+<tr><th>Table</th><th>With</th><th>Empty</th><th>Cells</th></tr>
 </thead>
 <tbody>
-<tr><td></td><td>     </td><td>      </td><td></td></tr>
-<tr><td>a   </td><td>     </td><td>  b   </td><td></td></tr>
-<tr><td></td><td> a   </td><td>      </td><td>  b</td></tr>
-<tr><td>a   </td><td>     </td><td>      </td><td>  b</td></tr>
-<tr><td></td><td> a   </td><td>  b   </td><td></td></tr>
+<tr><td></td><td></td><td></td><td></td></tr>
+<tr><td>a</td><td></td><td>b</td><td></td></tr>
+<tr><td></td><td>a</td><td></td><td>b</td></tr>
+<tr><td>a</td><td></td><td></td><td>b</td></tr>
+<tr><td></td><td>a</td><td>b</td><td></td></tr>
 </tbody>
 </table>
 <table>


### PR DESCRIPTION
Move the table row parse logic out of the render function and into the consume function where it belongs. This makes the table absy (AST) much more useful for people (like me) who want to parse markdown without rendering to HTML.