### PR TITLE
Fix #169

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,9 +5,9 @@ First of all, **thank you** for contributing, **you are awesome**! :)
 
 If you have an idea or found a bug, please [open an issue](https://github.com/cebe/markdown/issues/new) on github.
 
-If you want to contribute code, there a few rules to follow: 
+If you want to contribute code, there a few rules to follow:
 
-- I am following a code style that is basically [PSR-2](http://www.php-fig.org/psr/2/) but with TABS indentation (yes, I really do that ;) ).
+- I am following a code style that is basically [PSR-2](https://www.php-fig.org/psr/psr-2/) but with TABS indentation (yes, I really do that ;) ).
   I am not going to nit-pick on all the details about the code style but indentation is a must. The important part is that code is readable.
   Methods should be documented using phpdoc style.
 
@@ -31,6 +31,6 @@ where the input file contains the Markdown and the output file contains the expe
 You can run the tests after initializing the lib with composer(`composer install`) with the following command:
 
 	vendor/bin/phpunit
-	
+
 To create a new test case, create a `.md` file a`.html` with the same base name in the subfolders of
 the `/tests` directory. See existing files for examples.

--- a/GithubMarkdown.php
+++ b/GithubMarkdown.php
@@ -111,4 +111,28 @@ class GithubMarkdown extends Markdown
 			return parent::renderText($text);
 		}
 	}
+
+	/**
+	 * @inheritDoc
+	 *
+	 * Allows escaping newlines to create line breaks.
+	 *
+	 * @marker \
+	 */
+	protected function parseEscape($text)
+	{
+		$br = $this->html5 ? "<br>\n" : "<br />\n";
+
+		# If the backslash is followed by a newline.
+		# Note: GFM doesn't allow spaces after the backslash.
+		if ($text[1] === "\n") {
+
+			# Return the line break
+			return [["text", $br], 2];
+		}
+
+		# Otherwise parse the sequence normally
+		return parent::parseEscape($text);
+
+	}
 }

--- a/tests/github-data/issue-169.html
+++ b/tests/github-data/issue-169.html
@@ -1,0 +1,6 @@
+<p>test \ 
+with trailing space</p>
+<p>test <br />
+without trailing space</p>
+<p>test<br />
+without leading space</p>

--- a/tests/github-data/issue-169.md
+++ b/tests/github-data/issue-169.md
@@ -1,0 +1,8 @@
+test \ 
+with trailing space
+
+test \
+without trailing space
+
+test\
+without leading space


### PR DESCRIPTION
Added so that GFM has support for creating line breaks by prefixing the line feed with a backslash.

I didn't add any `render*` function for the line breaks, since newlines rendered by `renderText` are never tokenized either. Is that okay?