### PR TITLE
@inheritdocs to @inheritDoc Hacktoberfest

### DIFF
--- a/GithubMarkdown.php
+++ b/GithubMarkdown.php
@@ -98,7 +98,7 @@ class GithubMarkdown extends Markdown
 	}
 
 	/**
-	 * @inheritdocs
+	 * @inheritDoc
 	 *
 	 * Parses a newline indicated by two spaces on the end of a markdown line.
 	 */

--- a/Markdown.php
+++ b/Markdown.php
@@ -117,7 +117,7 @@ class Markdown extends Parser
 
 
 	/**
-	 * @inheritdocs
+	 * @inheritDoc
 	 *
 	 * Parses a newline indicated by two spaces on the end of a markdown line.
 	 */


### PR DESCRIPTION
Minor issue, but for Hacktoberfest, I thought I would correct it.

@inheritdocs is a typo.  Should be @inheritDoc

See [Inheritance](https://docs.phpdoc.org/latest/guides/inheritance.html)